### PR TITLE
Add prefix './' to path in _db:init

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "_db:delete": "rimraf .data/db",
-    "_db:init": "docker-compose exec -u postgres db /var/tmp/pg/load-data.sh",
+    "_db:init": "docker-compose exec -u postgres db ./var/tmp/pg/load-data.sh",
     "app:start": "cd app && npm start",
     "db:delete": "run-s db:stop _db:delete",
     "db:init": "run-s db:delete db:start _db:init",


### PR DESCRIPTION
By doing such, it allows the database to reliably work on both Mac and Windows; otherwise Windows users have to open the project within `WSL`, which is a hassle in itself, and after that there's still issues with mounting the database properly. 

Without the `./` prefix, the app and server can work, but no db queries can be made. I've tested this a few times on Windows + OSX, including deleting the db and starting from scratch, and this seems to work reliably.